### PR TITLE
Basic docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+ambergris:
+  image: ambergris/server
+  privileged: true
+  net: "host"
+  links:
+   - etcd
+etcd:
+  image: quay.io/coreos/etcd
+  ports:
+   - "2379:2379"
+  command: -advertise-client-urls http://0.0.0.0:2379 -listen-client-urls http://0.0.0.0:2379
+  volumes:
+   - ./default.etcd:/default.etcd
+dlisten:
+  image: bboreham/dlisten
+  links:
+   - etcd
+  volumes:
+   - /var/run/weave/weave.sock:/var/run/docker.sock


### PR DESCRIPTION
This is for running demos on a single host.  Running on multiple hosts requires some thought about how to contact a central `etcd`.

To use with instances on the weave network, run `docker-compose up` after `eval $(weave env)`.  Note there is a bug in weaveproxy which breaks the publication of port 2379 from `etcd` at this point.
